### PR TITLE
ci upgrades: py3.12, action versions

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -9,17 +9,16 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: x64
 
       - name: Install
         run: |


### PR DESCRIPTION
This PR contains the following changes:
- run tests with python 3.12
- upgrade github actions to their respective latest versions, this removes warning in the CI pipeline about deprecated node versions and brings in latest code and fixes from upstream
- remove explicitly setting architecture: x64 because it is the default value